### PR TITLE
Update PostgreSql.php

### DIFF
--- a/lib/CrEOF/Spatial/DBAL/Platform/PostgreSql.php
+++ b/lib/CrEOF/Spatial/DBAL/Platform/PostgreSql.php
@@ -117,6 +117,11 @@ class PostgreSql extends AbstractPlatform
      */
     public function convertToDatabaseValue(AbstractSpatialType $type, GeometryInterface $value)
     {
+        // Compatibilty with empty Geometry
+        if (strlen($value) === 2) {
+            return sprintf('%s EMPTY', $value->getType());
+        }
+        
         $sridSQL = null;
 
         if ($type instanceof GeographyType && null === $value->getSrid()) {


### PR DESCRIPTION
Query with empty geometries fail on PostgreSQL.
That patch creates a "XXXX EMPTY" string when the geometry is empty before submitting the parameter to PostgreSQL.